### PR TITLE
fix: querybuilder layout position of clear button and left arrow empt…

### DIFF
--- a/src/packages/@cqdg/components/queryBuilder/QueryBuilder.css
+++ b/src/packages/@cqdg/components/queryBuilder/QueryBuilder.css
@@ -12,6 +12,10 @@
 
 .query-builder .wrapper-builder{
   display: flex;
+  align-items: flex-start;
+}
+
+.query-builder.query-builder--no-filters .wrapper-builder {
   align-items: center;
 }
 


### PR DESCRIPTION
<img width="381" alt="Screen Shot 2020-11-25 at 3 21 46 PM" src="https://user-images.githubusercontent.com/98903/100278782-676d8380-2f33-11eb-8f5f-0fef06643a77.png">
<img width="216" alt="Screen Shot 2020-11-25 at 3 21 42 PM" src="https://user-images.githubusercontent.com/98903/100278794-6a687400-2f33-11eb-945d-28bde221618e.png">
<img width="269" alt="Screen Shot 2020-11-25 at 3 21 35 PM" src="https://user-images.githubusercontent.com/98903/100278812-718f8200-2f33-11eb-8a1a-0660cdfb3ca7.png">
