### PR TITLE
fix: #142 spacing for select all and none

### DIFF
--- a/src/packages/@ferlab-ui/core/containers/filters/types/MultipleChoice.css
+++ b/src/packages/@ferlab-ui/core/containers/filters/types/MultipleChoice.css
@@ -27,10 +27,13 @@
 }
 
 .fui-filters-actions .separator {
-  height: 10px;
+  height: 11px;
   align-self: center;
   background: #90A9C1;
-  margin: 0 4px;
+  margin: 0 5px;
+}
+.fui-filters-actions {
+  margin-bottom: 13px;
 }
 
 .fui-filters-actions .fui-filters-links {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74249528/101061441-80db8480-355e-11eb-8015-a21eb3a30a82.png)
